### PR TITLE
Add alerts to the prober

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -74,6 +74,8 @@ parameters:
       probeInterval: '10'
       metricsPort: 8080
       useTLS: 'true'
+      alerts:
+        enabled: false
       resources:
         requests:
           memory: '64Mi'

--- a/component/prober.jsonnet
+++ b/component/prober.jsonnet
@@ -179,10 +179,62 @@ local prometheusRule = {
   },
 };
 
+local alertRules = {
+  apiVersion: 'monitoring.coreos.com/v1',
+  kind: 'PrometheusRule',
+  metadata: {
+    name: params.name + '-alerts',
+    namespace: params.namespace,
+  },
+  spec: {
+    groups: [
+      {
+        name: 'rabbitmq.alerts',
+        rules: [
+          {
+            alert: 'RabbitMQDown',
+            expr: 'max by (job, cluster_id, namespace) (rabbitmq_functional_availability) == 0',
+            'for': '2m',
+            labels: {
+              severity: 'warning',
+              syn_team: 'schedar',
+              syn: 'true',
+              syn_component: 'rabbitmq-operator',
+            },
+            annotations: {
+              summary: 'RabbitMQ is down',
+              description: 'RabbitMQ in namespace {{ $labels.namespace }} has been down for more than 1 minute',
+            },
+          },
+          {
+            alert: 'RabbitMQProbeFailures',
+            expr: 'increase(rabbitmq_probe_failures_total[5m]) > 3',
+            'for': '0m',
+            labels: {
+              severity: 'warning',
+              syn_team: 'schedar',
+              syn: 'true',
+              syn_component: 'rabbitmq-operator',
+            },
+            annotations: {
+              summary: 'Multiple RabbitMQ probe failures',
+              description: 'RabbitMQ prober in namespace {{ $labels.namespace }} has failed {{ $value }} times in the last 5 minutes',
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+
 
 if params.enabled then {
   '20_prober_deployment': deployment,
   '21_prober_service': service,
   '22_prober_service_monitor': serviceMonitor,
   '22_prober_service_prom_rule': prometheusRule,
-} else {}
+} + (
+  if params.alerts.enabled then {
+    '24_prober_alert_rules': alertRules,
+  } else {}
+) else {}

--- a/tests/custom.yml
+++ b/tests/custom.yml
@@ -4,6 +4,8 @@ parameters:
   rabbitmq_operator:
     prober:
       enabled: true
+      alerts:
+        enabled: true
     rabbitmq:
       replicas: 3
       affinity:

--- a/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/prober/24_prober_alert_rules.yaml
+++ b/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/prober/24_prober_alert_rules.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rabbitmq-prober-alerts
+  namespace: rabbitmq
+spec:
+  groups:
+    - name: rabbitmq.alerts
+      rules:
+        - alert: RabbitMQDown
+          annotations:
+            description: RabbitMQ in namespace {{ $labels.namespace }} has been down
+              for more than 1 minute
+            summary: RabbitMQ is down
+          expr: max by (job, cluster_id, namespace) (rabbitmq_functional_availability)
+            == 0
+          for: 2m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: rabbitmq-operator
+            syn_team: schedar
+        - alert: RabbitMQProbeFailures
+          annotations:
+            description: RabbitMQ prober in namespace {{ $labels.namespace }} has
+              failed {{ $value }} times in the last 5 minutes
+            summary: Multiple RabbitMQ probe failures
+          expr: increase(rabbitmq_probe_failures_total[5m]) > 3
+          for: 0m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: rabbitmq-operator
+            syn_team: schedar


### PR DESCRIPTION
This PR will add 2 alerts:
* Test RabbitMQ if it's down
* Test Probe itself if it's down


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
