### PR TITLE
Support for generating a custom LoadBalancer service with Espejote

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -65,6 +65,9 @@ parameters:
         enabled: false
         group: group
       service: {}
+      custom_lb_service:
+        enabled: false
+        loadBalancerClass: ""
 
     prober:
       enabled: false

--- a/component/espejote-templates/rabbitmq-lb-service.jsonnet
+++ b/component/espejote-templates/rabbitmq-lb-service.jsonnet
@@ -1,0 +1,22 @@
+local esp = import 'espejote.libsonnet';
+local config = import 'rabbitmq-lb-service/config.json';
+
+local svcs = esp.context().services;
+assert std.length(svcs) == 1 : 'Expected exactly 1 service in services context';
+local svc = svcs[0];
+
+{
+  apiVersion: 'v1',
+  kind: 'Service',
+  metadata: {
+    annotations: std.get(svc.metadata, 'annotations', {}),
+    name: '%s-lb' % svc.metadata.name,
+    namespace: svc.metadata.namespace,
+  },
+  spec: {
+    type: 'LoadBalancer',
+    loadBalancerClass: '%(loadBalancerClass)s' % config,
+    ports: svc.spec.ports,
+    selector: svc.spec.selector,
+  },
+}

--- a/component/rabbitmq.jsonnet
+++ b/component/rabbitmq.jsonnet
@@ -248,9 +248,36 @@ local espLBService =
     },
   };
 
+local needs_cnp = std.member(inv.applications, 'cilium');
+local cnp =
+  kube._Object('cilium.io/v2', 'CiliumNetworkPolicy', '%s-allow-from-world' % params.name) {
+    metadata+: {
+      namespace: params.namespace,
+    },
+    spec: {
+      endpointSelector: {
+        matchLabels: {
+          // NOTE(sg): Assumption here is that the pods have label
+          // `app.kubernetes.io/name=<name of RabbitmqCluster custom resource>`
+          'app.kubernetes.io/name': params.name,
+        },
+      },
+      ingress: [ {
+        fromEntities: [ 'world' ],
+        toPorts: [ {
+          ports: [
+            { port: '5671', protocol: 'TCP' },
+            { port: '5672', protocol: 'TCP' },
+          ],
+        } ],
+      } ],
+    },
+  };
+
 if params.enabled then {
   '10_namespace': namespace,
   '20_rabbitmq_cluster': rabbitmqCluster,
+  [if needs_cnp then '30_rabbitmq_cilium_networkpolicy']: cnp,
   [if params.custom_lb_service.enabled then '99_rabbitmq_lb_service']:
     [ espSA, espRole, espRoleBinding, espConfig, espLBService ],
 } + (

--- a/component/rabbitmq.jsonnet
+++ b/component/rabbitmq.jsonnet
@@ -1,4 +1,5 @@
 // rabbitmq.jsonnet
+local esp = import 'lib/espejote.libsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libsonnet';
 
@@ -147,9 +148,111 @@ local managementRoute = {
   },
 };
 
+local espSA = kube.ServiceAccount('rabbitmq-lb-service-manager') {
+  metadata+: {
+    namespace: params.namespace,
+  },
+};
+
+local espRole = kube.Role('rabbitmq-lb-service-manager') {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  rules: [
+    {
+      apiGroups: [ '' ],
+      resources: [ 'services' ],
+      verbs: [ '*' ],
+    },
+    {
+      apiGroups: [ 'espejote.io' ],
+      resources: [ 'jsonnetlibraries' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+  ],
+};
+
+local espRoleBinding = kube.RoleBinding('rabbitmq-lb-service-manager') {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  roleRef_: espRole,
+  subjects_: [ espSA ],
+};
+
+local espConfig =
+  esp.jsonnetLibrary('rabbitmq-lb-service', params.namespace) {
+    spec: {
+      data: {
+        'config.json': std.manifestJson(params.custom_lb_service),
+      },
+    },
+  };
+
+local espLBService =
+  esp.managedResource('rabbitmq-lb-service', params.namespace) {
+    metadata+: {
+      annotations: {
+        'syn.tools/description': |||
+          This ManagedResource watches the Service created by the
+          rabbitmq-operator for the RabbitmqCluster resource that's created by
+          the Commodore component.
+
+          The ManagedResource creates a copy of the RabbitmqCluster's primary
+          service with `spec.type=LoadBalancer` and a user-configurable
+          `spec.loadBalancerClass`. The values of `metadata.annotations`,
+          `spec.ports` and `spec.selector` are copied from the
+          operator-managed Service and updated whenever the operator makes any
+          changes.
+        |||,
+      },
+    },
+    spec: {
+      applyOptions: {
+        force: true,
+      },
+      context: [
+        {
+          name: 'services',
+          resource: {
+            apiVersion: 'v1',
+            kind: 'Service',
+            // NOTE(sg): Assumption here is that the service has the same name
+            // as the RabbitmqCluster custom resource.
+            name: params.name,
+            namespace: params.namespace,
+          },
+        },
+      ],
+      triggers: [
+        {
+          name: 'service',
+          watchContextResource: {
+            name: 'services',
+          },
+        },
+        {
+          name: 'jsonnetlib',
+          watchResource: {
+            apiVersion: 'espejote.io/v1alpha1',
+            kind: 'JsonnetLibrary',
+            name: espConfig.metadata.name,
+            namespace: params.namespace,
+          },
+        },
+      ],
+      serviceAccountRef: {
+        name: espSA.metadata.name,
+      },
+      template: importstr 'espejote-templates/rabbitmq-lb-service.jsonnet',
+    },
+  };
+
 if params.enabled then {
   '10_namespace': namespace,
   '20_rabbitmq_cluster': rabbitmqCluster,
+  [if params.custom_lb_service.enabled then '99_rabbitmq_lb_service']:
+    [ espSA, espRole, espRoleBinding, espConfig, espLBService ],
 } + (
   if params.rbac.enabled then {
     '30_rbac_role': role,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -307,6 +307,14 @@ The value of this parameter is used as-is for `spec.service` of the resulting re
 
 IMPORTANT: The only fields supported by the operator are `type` and `annotations`.
 
+[TIP]
+====
+When the Cilium Commodore component is present on the cluster, the component unconditionally deploys a `CiliumNetworkPolicy` which allows traffic on `5671/tcp` and `5672/tcp` from outside the cluster (Cilium entity `world`).
+This policy ensures that accessing the RabbitMQ cluster over an LB service works correctly on Cilium-enabled clusters.
+
+Network policies to allow access from within the cluster must be managed separately.
+====
+
 === `rabbitmq.custom_lb_service.enabled`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -307,6 +307,28 @@ The value of this parameter is used as-is for `spec.service` of the resulting re
 
 IMPORTANT: The only fields supported by the operator are `type` and `annotations`.
 
+=== `rabbitmq.custom_lb_service.enabled`
+
+[horizontal]
+type:: boolean
+default:: `false`
+
+When this parameter is set to true, the component deploys an Espejote `ManagedResource` which creates a copy of the `RabbitmqCluster`-owned primary service with `spec.type=LoadBalancer` and a configurable `spec.loadBalancerClass`.
+For environments, where setting `spec.loadBalancerClass` isn't required, users should prefer setting `rabbitmq.service.type=LoadBalancer`.
+
+The `ManagedResource` copies the primary service's `metadata.annotations`, `spec.ports` and `spec.selector`.
+Users that want to customize the LoadBalancer service via annotations -- for example for requesting specific IPs from Cilium LB-IPAM -- should add these annotations in `rabbitmq.service.annotations`.
+This should simplify removing this feature if the operator gains support for custom `spec.loadBalancerClass` in the future.
+
+=== `rabbitmq.custom_lb_service.loadBalancerClass`
+
+[horizontal]
+type:: string
+default:: `""`
+
+This parameter allows users to provide a load balancer class names for the custom LoadBalancer service.
+The value is used as `spec.loadBalancerClass` for the LB service without any validation.
+
 == Prober Configuration
 
 === `prober.enabled`

--- a/tests/custom.yml
+++ b/tests/custom.yml
@@ -1,5 +1,6 @@
 # Overwrite parameters here
-
+applications:
+  - cilium
 parameters:
   kapitan:
     dependencies:

--- a/tests/custom.yml
+++ b/tests/custom.yml
@@ -1,6 +1,11 @@
 # Overwrite parameters here
 
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.12.0/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
   rabbitmq_operator:
     prober:
       enabled: true
@@ -27,3 +32,6 @@ parameters:
       service:
         annotations:
           lbipam.cilium.io/ips: 192.0.2.50
+      custom_lb_service:
+        enabled: true
+        loadBalancerClass: io.cilium/l2-announcer

--- a/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/rabbitmq/30_rabbitmq_cilium_networkpolicy.yaml
+++ b/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/rabbitmq/30_rabbitmq_cilium_networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: rabbitmq-allow-from-world
+  name: rabbitmq-allow-from-world
+  namespace: rabbitmq
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+  ingress:
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: '5671'
+              protocol: TCP
+            - port: '5672'
+              protocol: TCP

--- a/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/rabbitmq/99_rabbitmq_lb_service.yaml
+++ b/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/rabbitmq/99_rabbitmq_lb_service.yaml
@@ -1,0 +1,129 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: rabbitmq-lb-service-manager
+  name: rabbitmq-lb-service-manager
+  namespace: rabbitmq
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: rabbitmq-lb-service-manager
+  name: rabbitmq-lb-service-manager
+  namespace: rabbitmq
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - '*'
+  - apiGroups:
+      - espejote.io
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: rabbitmq-lb-service-manager
+  name: rabbitmq-lb-service-manager
+  namespace: rabbitmq
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rabbitmq-lb-service-manager
+subjects:
+  - kind: ServiceAccount
+    name: rabbitmq-lb-service-manager
+    namespace: rabbitmq
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: rabbitmq-lb-service
+  name: rabbitmq-lb-service
+  namespace: rabbitmq
+spec:
+  data:
+    config.json: |-
+      {
+          "enabled": true,
+          "loadBalancerClass": "io.cilium/l2-announcer"
+      }
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    syn.tools/description: |
+      This ManagedResource watches the Service created by the
+      rabbitmq-operator for the RabbitmqCluster resource that's created by
+      the Commodore component.
+
+      The ManagedResource creates a copy of the RabbitmqCluster's primary
+      service with `spec.type=LoadBalancer` and a user-configurable
+      `spec.loadBalancerClass`. The values of `metadata.annotations`,
+      `spec.ports` and `spec.selector` are copied from the
+      operator-managed Service and updated whenever the operator makes any
+      changes.
+  labels:
+    app.kubernetes.io/name: rabbitmq-lb-service
+  name: rabbitmq-lb-service
+  namespace: rabbitmq
+spec:
+  applyOptions:
+    force: true
+  context:
+    - name: services
+      resource:
+        apiVersion: v1
+        kind: Service
+        name: rabbitmq
+        namespace: rabbitmq
+  serviceAccountRef:
+    name: rabbitmq-lb-service-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+    local config = import 'rabbitmq-lb-service/config.json';
+
+    local svcs = esp.context().services;
+    assert std.length(svcs) == 1 : 'Expected exactly 1 service in services context';
+    local svc = svcs[0];
+
+    {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        annotations: std.get(svc.metadata, 'annotations', {}),
+        name: '%s-lb' % svc.metadata.name,
+        namespace: svc.metadata.namespace,
+      },
+      spec: {
+        type: 'LoadBalancer',
+        loadBalancerClass: '%(loadBalancerClass)s' % config,
+        ports: svc.spec.ports,
+        selector: svc.spec.selector,
+      },
+    }
+  triggers:
+    - name: service
+      watchContextResource:
+        name: services
+    - name: jsonnetlib
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: rabbitmq-lb-service
+        namespace: rabbitmq


### PR DESCRIPTION
The operator currently doesn't support setting `spec.loadBalancerClass` when setting `spec.service.type=LoadBalancer` for a RabbitMQ cluster.

However, we must be able to set the `loadBalancerClass` in order to ensure the LB service is backed by the desired LB implementation on clusters which provide multiple LB implementations.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
