### PR TITLE
Allow setting additionalConfig and set vm_memory_high_watermark.absolute

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -44,6 +44,7 @@ parameters:
       image: docker.io/bitnamilegacy/rabbitmq:3.11.26-debian-11-r0
       affinity: {}
       plugins: []
+      additionalConfig: ''
       persistence:
         storage: 3Gi
       resources:

--- a/component/rabbitmq.jsonnet
+++ b/component/rabbitmq.jsonnet
@@ -14,6 +14,15 @@ local namespace = kube.Namespace(params.namespace) {
   spec: {},
 };
 
+local userOverridesWatermark = std.length(std.findSubstr('vm_memory_high_watermark.absolute', params.additionalConfig)) > 0;
+local additionalConfig = std.join('\n', std.filter(
+  function(s) s != '',
+  [
+    if !userOverridesWatermark then 'vm_memory_high_watermark.absolute = %s' % params.resources.limits.memory,
+    params.additionalConfig,
+  ]
+));
+
 local rabbitmqCluster = {
   apiVersion: 'rabbitmq.com/v1beta1',
   kind: 'RabbitmqCluster',
@@ -24,6 +33,7 @@ local rabbitmqCluster = {
   spec: {
     rabbitmq: {
       additionalPlugins: params.plugins,
+      additionalConfig: additionalConfig,
     },
     image: params.image,
     persistence: {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -192,6 +192,20 @@ default:: `[]`
 
 List of additional RabbitMQ plugins to enable.
 
+=== `rabbitmq.additionalConfig`
+
+[horizontal]
+type:: string
+default:: `""`
+
+Additional configuration to append to `rabbitmq.conf`.
+The value is appended after the component-managed configuration entries.
+
+The component always sets `vm_memory_high_watermark.absolute` to the value of `rabbitmq.resources.limits.memory`.
+Any configuration provided here is appended after that line.
+
+NOTE: Changing this value on an existing `RabbitmqCluster` will trigger a StatefulSet rolling restart and cause temporary RabbitMQ downtime.
+
 === `rabbitmq.persistence.storage`
 
 [horizontal]
@@ -507,6 +521,22 @@ parameters:
       alerts:
         enabled: true
 ----
+
+=== RabbitMQ with Additional Configuration
+
+[source,yaml]
+----
+parameters:
+  rabbitmq_operator:
+    rabbitmq:
+      resources:
+        limits:
+          memory: 4Gi  # <1>
+      additionalConfig: |
+        channel_max = 100
+----
+<1> `vm_memory_high_watermark.absolute` is automatically set to this value (`4Gi`).
+Any entries in `additionalConfig` are appended after it.
 
 === RabbitMQ with Node Affinity
 

--- a/tests/custom.yml
+++ b/tests/custom.yml
@@ -27,7 +27,7 @@ parameters:
         enabled: true
       rbac:
         enabled: true
-        group: group  # deprecated, legacy support
+        group: group # deprecated, legacy support
         groups:
           - group
           - my-other-group
@@ -37,6 +37,9 @@ parameters:
       service:
         annotations:
           lbipam.cilium.io/ips: 192.0.2.50
+      additionalConfig: |
+        channel_max = 100
+        vm_memory_high_watermark.absolute = 2Gi
       custom_lb_service:
         enabled: true
         loadBalancerClass: io.cilium/l2-announcer

--- a/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/rabbitmq/20_rabbitmq_cluster.yaml
+++ b/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/rabbitmq/20_rabbitmq_cluster.yaml
@@ -22,6 +22,7 @@ spec:
   persistence:
     storage: 3Gi
   rabbitmq:
+    additionalConfig: vm_memory_high_watermark.absolute = 3Gi
     additionalPlugins:
       - rabbitmq_shovel
       - rabbitmq_shovel_management

--- a/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/rabbitmq/20_rabbitmq_cluster.yaml
+++ b/tests/golden/custom/rabbitmq-operator/rabbitmq-operator/rabbitmq/20_rabbitmq_cluster.yaml
@@ -22,7 +22,9 @@ spec:
   persistence:
     storage: 3Gi
   rabbitmq:
-    additionalConfig: vm_memory_high_watermark.absolute = 3Gi
+    additionalConfig: |
+      channel_max = 100
+      vm_memory_high_watermark.absolute = 2Gi
     additionalPlugins:
       - rabbitmq_shovel
       - rabbitmq_shovel_management

--- a/tests/golden/defaults/rabbitmq-operator/rabbitmq-operator/rabbitmq/20_rabbitmq_cluster.yaml
+++ b/tests/golden/defaults/rabbitmq-operator/rabbitmq-operator/rabbitmq/20_rabbitmq_cluster.yaml
@@ -15,6 +15,7 @@ spec:
   persistence:
     storage: 3Gi
   rabbitmq:
+    additionalConfig: vm_memory_high_watermark.absolute = 3Gi
     additionalPlugins: []
   replicas: 1
   resources:


### PR DESCRIPTION
## Summary

This allows configuration additionalConfig and setts the vm_memory_high_watermark.absolute to the configured limits of the pod

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.